### PR TITLE
removing deprecated X-Frame-Options header in favor of CSP

### DIFF
--- a/gatsby-static-server/Dockerfile
+++ b/gatsby-static-server/Dockerfile
@@ -24,7 +24,8 @@ ENV CSP_IMG_SRC=""
 ENV CSP_MEDIA_SRC=""
 ENV CSP_DEFAULT_SRC=""
 ENV CSP_REPORT_URI=""
-ENV CSP_FRAME_ANCESTORS=""
+# default to blocking the site being embedded elsewhere
+ENV CSP_FRAME_ANCESTORS="frame-ancestors 'none';"
 
 # Configure which port nginx listens on. By default just listen on 80
 # for regular traffic and 81 for the metrics route

--- a/gatsby-static-server/templates/default.conf.template
+++ b/gatsby-static-server/templates/default.conf.template
@@ -13,7 +13,6 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Content-Security-Policy $csp_header always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
   }
 
   location = /sw.js {
@@ -28,7 +27,6 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Content-Security-Policy $csp_header always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
     absolute_redirect off;
   }
 


### PR DESCRIPTION
The growth team is creating a widget to be embedded on external partner websites, so we need a way to allow the site to be embedded as an iframe.

We were previously blocking all embedding with the `X-Frame-Options` header which has now been deprecated in favor of using the Content-Security-Policy directive. This PR updates nginx to default the CSP header to block all embedding, but this can be configured via environment variables to allow it in cases where we need it.